### PR TITLE
fix(thorvg): fix compilation on thread-less platforms

### DIFF
--- a/src/libs/thorvg/tvgTaskScheduler.h
+++ b/src/libs/thorvg/tvgTaskScheduler.h
@@ -26,19 +26,23 @@
 #ifndef _TVG_TASK_SCHEDULER_H_
 #define _TVG_TASK_SCHEDULER_H_
 
+#ifdef THORVG_THREAD_SUPPORT
 #include <mutex>
 #include <condition_variable>
 #include <thread>
+#endif
 
 #include "tvgCommon.h"
 #include "tvgInlist.h"
 
+#ifdef THORVG_THREAD_SUPPORT
 using std::mutex;
 using std::condition_variable;
 using std::unique_lock;
 using std::thread;
 using std::atomic;
 using std::try_to_lock;
+#endif
 
 namespace tvg {
 


### PR DESCRIPTION
Fixes: #8362

Only if `THORVG_THREAD_SUPPORT` is defined, conditionally include `<mutex>`, `<condition_variable>`, and `<thread>` along with the related `using` statements.